### PR TITLE
Fix HTML markup to (almost) valid HTML

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -109,6 +109,8 @@ height:80%;
 	height:100%;
 	width:100%;
 	table-layout:fixed;
+	border-spacing:0;
+	border-collapse:collapse;
 }
 .pulsanti td{
 	width:25%;

--- a/index.htm
+++ b/index.htm
@@ -49,10 +49,10 @@
 				</div>
 				<div class="keys">
 
-					<table class="pulsanti" cellspacing="0" border="0" cellpadding="0">
+					<table class="pulsanti">
 						<tr>
-							<td><a href="javascript:;" class="buttn insert ui-el par" data-val="(" data-long=")" data-longtap="1"><span class="label rel">(<span class="apice apM tohide">)</span></span></span></a></td>
-							<td><a href="javascript:;" class="buttn action ui-el third" data-action="M" data-longtap="1" id="btn-m"><span class="label rel">M<span class="apice apM">&times;</span></a></td>
+							<td><a href="javascript:;" class="buttn insert ui-el par" data-val="(" data-long=")" data-longtap="1"><span class="label rel">(<span class="apice apM tohide">)</span></span></a></td>
+							<td><a href="javascript:;" class="buttn action ui-el third" data-action="M" data-longtap="1" id="btn-m"><span class="label rel">M<span class="apice apM">&times;</span></span></a></td>
 							<td><a href="javascript:;" class="buttn action ui-el third" data-action="Mr"><span class="label rel">Mr</span></a></td>
 							<td><a href="javascript:;" class="buttn insert ui-el oper" data-val="+"><span class="label">+</span></a></td>
 						</tr>
@@ -84,7 +84,7 @@
 						</tr>
 					</table>
 					
-						<table class="pulsanti extra" cellspacing="0" border="0" cellpadding="0">
+						<table class="pulsanti extra">
 						<tr>								
 							<td><a id="close-tonda" href="javascript:;" class="buttn insert ui-el par" data-val=")"><span class="label">)</span></a></td>
 							<td><a href="javascript:;" class="buttn insert ui-el par" data-val="[" data-long="]" data-longtap="1"><span class="label rel">[<span class="apice apM">]</span></span></a></td>
@@ -139,7 +139,7 @@
 			<div class="info-page scrollable">
 				<div class="page-content page">
 					<div class="section border">
-						<a href="javascript:;" class="ui-el backbutton left"><</a>
+						<a href="javascript:;" class="ui-el backbutton left">&lt;</a>
 						<div class="clear"></div>
 						<h2 class="left">Good Calc</h2>
 						<div class="clear"></div>
@@ -152,35 +152,35 @@
 							<div class="row page-header"><span data-l10n-id="TitleMemory">Memory</span></div>
 							<div class="row">M <span class="ugul">=</span> <span data-l10n-id="M-symbol">write into memory</span></div>
 							<div class="row">Mr <span class="ugul">=</span> <span data-l10n-id="Mr-symbol">read from memory</span></div>
-							<div class="row">M<span class="apice_">&times;</span> <span class="ugul">=</span> <span data-l10n-id="M-symbol-cross">Tap&Hold, clear memory</span></div>
+							<div class="row">M<span class="apice_">&times;</span> <span class="ugul">=</span> <span data-l10n-id="M-symbol-cross">Tap&amp;Hold, clear memory</span></div>
 						</div>
 					</div>
 					<div class="section border">
 						<div class="speg">
-							<div class="row page-header"><span data-l10n-id="TitleHistory">History</span></span></div>
+							<div class="row page-header"><span data-l10n-id="TitleHistory">History</span></div>
 							<div class="row">&uarr; &darr; <span class="ugul">=</span> <span data-l10n-id="History-swipe">swipe up/down on calc bar</span></div>
 						</div>
 					</div>
 					<div class="section border">
 						<div class="speg">
 							<div class="row page-header"><span data-l10n-id="TitleMath">Math</span></div>
-							<div class="row"><span class="apice_">2</span>&radic;</span> <span class="ugul">=</span> sqrt()</div>
-							<div class="row"><span class="apice_">x</span>&radic;</span> <span class="ugul">=</span> <span class="pedice">x</span>root()</div>
-							<div class="row">x<span class="apice_">y</span></span> <span class="ugul">=</span> x^y</div>
+							<div class="row"><span class="apice_">2</span>&radic; <span class="ugul">=</span> sqrt()</div>
+							<div class="row"><span class="apice_">x</span>&radic; <span class="ugul">=</span> <span class="pedice">x</span>root()</div>
+							<div class="row">x<span class="apice_">y</span> <span class="ugul">=</span> x^y</div>
 						</div>
 					</div>	
 					<div class="section border">
 						<div class="speg">
 							<div class="row page-header"><span data-l10n-id="TitleSymbols">Symbols</span></div>
 							<div class="row text">
-								) ] } = <span  data-l10n-id="TapAndHold">Tap&Hold</span> ( [ {
+								) ] } = <span  data-l10n-id="TapAndHold">Tap&amp;Hold</span> ( [ {
 							</div>
 						</div>
 					</div>
 					<div class="section ">
 						<div class="speg">
 							<div class="row text" data-l10n-id="DeleteAll">
-								Delete all = Tap&Hold delete button 
+								Delete all = Tap&amp;Hold delete button
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
- `index.htm`: fix stray end tags.
- `index.htm`: fix HTML entities.
- `index.htm`: remove cellspacing, border, and cellpadding attributes.
- `css/base.css`: added table styling to the css.
