### PR TITLE
Add Brazilian Portuguese locale

### DIFF
--- a/lang/brazilian-portuguese.properties
+++ b/lang/brazilian-portuguese.properties
@@ -1,0 +1,11 @@
+﻿SubTitleApp = Calculadora científica simples e poderosa
+TapAndHold = Mantena pressionado
+DeleteAll = Apagar tudo = mantenha pressionado a tecla Apagar
+M-symbol = Armazenar na memória
+Mr-symbol = Ler da memória
+M-symbol-cross = Apagar a memória
+History-swipe = deslizar para cima/baixo na barra de cálculo
+TitleMemory = Memória
+TitleHistory = Histórico
+TitleMath = Matemática
+TitleSymbols = Símbolos

--- a/locales.ini
+++ b/locales.ini
@@ -17,3 +17,6 @@
 
 [sr-Latn]
 @import url(lang/serbian-latin.properties)
+
+[pt-br]
+@import url(lang/brazilian-portuguese.properties)


### PR DESCRIPTION
Could not find this in the actual app running in a Firefox OS device, but when I saw it was a short code, I decided to translate it.
